### PR TITLE
Plotting backend fix

### DIFF
--- a/camd/analysis.py
+++ b/camd/analysis.py
@@ -503,7 +503,7 @@ class StabilityAnalyzer(AnalyzerBase):
             plotkwargs.update({"linestyle": "--"})
         else:
             plotkwargs.update({"linestyle": "-"})
-        plotter = PDPlotter(pd, **plotkwargs)
+        plotter = PDPlotter(pd, backend='matplotlib', **plotkwargs)
 
         getplotkwargs = {"label_stable": False} if finalize else {}
         plot = plotter.get_plot(**getplotkwargs)

--- a/camd/analysis.py
+++ b/camd/analysis.py
@@ -520,7 +520,7 @@ class StabilityAnalyzer(AnalyzerBase):
             # measure stabilities wrt. the ultimate hull.
             pd = PhaseDiagram(filtered["entry"].values, elements=pg_elements)
             plotter = PDPlotter(
-                pd, **{"markersize": 0, "linestyle": "-", "linewidth": 2}
+                pd, backend="matplotlib", **{"markersize": 0, "linestyle": "-", "linewidth": 2}
             )
             plot = plotter.get_plot(plt=plot)
 


### PR DESCRIPTION
Pymatgen's recently refactored it's plotting backend to use plotly.  In the long term, I think we should refactor to take advantage of that, but in the short term, I've just used the matplotlib fallback.